### PR TITLE
kubectl v1.10.0 output change fix

### DIFF
--- a/kns
+++ b/kns
@@ -18,7 +18,7 @@ namespace="$(kubectl config get-contexts "$current" | awk "/$current/ {print \$5
 if [ -z "$namespace" ]; then
   namespace="default"
 fi
-selected=$( (kubectl get namespaces -o name | sed "s-namespaces/--"; echo $namespace ) | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> " --preview "kubectl --namespace {} get pods")
+selected=$( (kubectl get namespaces -o name | sed "s-namespaces*/--"; echo $namespace ) | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> " --preview "kubectl --namespace {} get pods")
 if [ ! -z "$selected" ]; then
   kubectl config set-context "$current" "--namespace=$selected" >/dev/null
   echo "Set context namespace to \"$selected\""


### PR DESCRIPTION
The addition of a * following the s allows the change in 1.10 from outputting "namespaces/" to "namespace/" to work without breaking backward compatibility.

One could argue that "s{0,1}" would be more correct, but I think :-
* It would require sed -E
* It might not work on mac
* s* looks fine
* I highly doubt that worrying about "namespacesssssss/" is a major issue

Cheers